### PR TITLE
Fix wofs product spec

### DIFF
--- a/product_definitions/ls_usgs_wofs_scene.yaml
+++ b/product_definitions/ls_usgs_wofs_scene.yaml
@@ -9,7 +9,7 @@ metadata:
 
 measurements: 
       - name: 'water'
-        dtype: int16
+        dtype: uint8
         units: '1'
         nodata: 1
         flags_definition:

--- a/product_definitions/ls_usgs_wofs_scene.yaml
+++ b/product_definitions/ls_usgs_wofs_scene.yaml
@@ -26,6 +26,7 @@ measurements:
             nodata:
                 bits: 0
                 values: 
+                    0: false
                     1: true
                 description: No data
             sea:


### PR DESCRIPTION
- wrong `dtype`
- missing `nodata=False` in mask flags